### PR TITLE
[FIX] 버튼 height, border-radius 는 props를 받지않음

### DIFF
--- a/becok/src/components/DetailedInput/DetailedStep.jsx
+++ b/becok/src/components/DetailedInput/DetailedStep.jsx
@@ -131,8 +131,8 @@ const NextButton = styled.button`
   right: 5%;
   bottom: 15%;
   width: ${(props) => (props.step === 6 ? "15.3vw" : "5.2vw")};
-  height: ${(props) => (props.step === 6 ? "5.2vw" : "5.2vw")};
-  border-radius: ${(props) => (props.step === 6 ? "5.2vw" : "50%")};
+  height: 5.2vw;
+  border-radius: 5.2vw;
   background-color: #dfdfdf;
   stroke: #666;
   border: none;


### PR DESCRIPTION
  <br/>
### 🔎 Summary

- 버튼 height, border-radius 는 props를 받지않음

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
